### PR TITLE
Fix LayoutLM BBX Normalization Bug

### DIFF
--- a/docai/annotations/bbx_utils.py
+++ b/docai/annotations/bbx_utils.py
@@ -6,23 +6,6 @@ and converting them into formats needed for different ML models.
 from docai.generated.models.bounding_box_dto import BoundingBoxDto
 
 
-def butler_bbx_to_layoutlm(butler_bbx):
-    """
-    Converts a bounding box in the format used by Butler into the format
-    used by LayoutLM.
-
-    Butler bounding boxes are float values between 0 and 1
-
-    LayoutLM expects bounding boxes to be normalized by 1000.
-    """
-    width = int(butler_bbx["width"] * 1000)
-    height = int(butler_bbx["height"] * 1000)
-    top = int(butler_bbx["top"] * 1000)
-    left = int(butler_bbx["left"] * 1000)
-
-    return [left, top, left + width, top + height]
-
-
 def butler_bbx_to_min_max(butler_bbx: BoundingBoxDto):
     """
     Converts a bounding box in the format used by Butler into the following format:

--- a/docai/annotations/layoutlm_utils.py
+++ b/docai/annotations/layoutlm_utils.py
@@ -4,7 +4,7 @@ from docai.annotations.ner_utils import DocumentNerAnnotation
 
 
 def normalize_bounding_box(bbx: List[int]) -> List[int]:
-    normalize_bounding_box = list(map(lambda point: point * 1000, bbx))
+    normalize_bounding_box = list(map(lambda point: int(point * 1000), bbx))
     return normalize_bounding_box
 
 


### PR DESCRIPTION
Fixes a minor bug in the normalization of bounding boxes for layoutlm. Bounding boxes need to be in int format in order for inference to work correctly.