### PR TITLE
fix: Fix typing issue by using typing_extensions

### DIFF
--- a/docai/training/layoutlm_metrics.py
+++ b/docai/training/layoutlm_metrics.py
@@ -1,8 +1,14 @@
-from typing import Callable, Dict, List, Literal
+import sys
+from typing import Callable, Dict, List
 
 import evaluate
 import numpy as np
 from transformers import EvalPrediction
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 SPECIAL_TOKEN = -100
 


### PR DESCRIPTION
### Related Issues
- N/A

### Summary of Changes
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
Bug caused by Literal type in typing only existing in Python 3.8.

Solved by using typing_extensions which is backwards compatible. 

### Test Plan
Manually verifying

### Checklist
- [X] PR title uses [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Changes are properly tested
- [X] Changes are properly documented
