### PR TITLE
fix: Add seqeval to Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,7 @@ typing-extensions = "*"
 transformers = "*"
 evaluate = "*"
 numpy = "*"
+seqeval = "*"
 
 [dev-packages]
 black = "*"


### PR DESCRIPTION
### Related Issues
- N/A

### Summary of Changes
 <!--- In case of a bug: Describe what caused the issue and how you solved it -->
Bug: seqeval is a dependency of the generate_layoutlm_compute_eval_metric_fn which was not included in the Pipfile
Fix: add seqeval to the Pipfile

### Test Plan
Manually verified

### Checklist
- [X] PR title uses [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Changes are properly tested
- [X] Changes are properly documented
