### PR TITLE
fix: pypi upload url

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ poetry config repositories.testpypi https://test.pypi.org/legacy/
 poetry config pypi-token.testpypi <testpypi token>
 
 # setup for pypi
-poetry config repositories.pypi https://pypi.org/legacy/
+poetry config repositories.pypi https://upload.pypi.org/legacy/
 poetry config pypi-token.pypi <pypi token>
 ```
 


### PR DESCRIPTION
### Related Issues
- N/A

### Summary of Changes
 pypi upload URL was documented incorrectly

### Test Plan
- [x] tested by publishing 0.1.0 of docai-py to official PyPI

### Checklist
- [x] PR title uses [conventional commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes are properly tested
- [x] Changes are properly documented
